### PR TITLE
Set valid Swift 5 version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,5 +18,5 @@ let package = Package(
             dependencies: ["Semver"],
             path: "Tests")
     ],
-    swiftLanguageVersions: [.version("5.1")]
+    swiftLanguageVersions: [.version("5")]
 )


### PR DESCRIPTION
Fix up compatibility with current tools -- the valid values for `swiftc -swift-version` are 4, 4.2, and 5.

I think '5.1' has always been invalid here but they've just started checking it recently.

Without this change I can't build the package on Swift 5.3, it says:
```shell
; swift build
<unknown>:0: error: invalid value '5.1' in '-swift-version 5.1'
<unknown>:0: note: valid arguments to '-swift-version' are '4', '4.2', '5'
<unknown>:0: error: invalid value '5.1' in '-swift-version 5.1'
<unknown>:0: note: valid arguments to '-swift-version' are '4', '4.2', '5'
<unknown>:0: error: invalid value '5.1' in '-swift-version 5.1'
<unknown>:0: note: valid arguments to '-swift-version' are '4', '4.2', '5'
;
; swift --version
Apple Swift version 5.3.2 (swiftlang-1200.0.45 clang-1200.0.32.28)
Target: x86_64-apple-darwin20.2.0
```

